### PR TITLE
Switch back to native types when array is detected

### DIFF
--- a/src/main/groovy/com/toastcoders/vmware/yavijava/parsers/DataObjectWSDLParserImpl.groovy
+++ b/src/main/groovy/com/toastcoders/vmware/yavijava/parsers/DataObjectWSDLParserImpl.groovy
@@ -68,6 +68,13 @@ class DataObjectWSDLParserImpl implements WSDLParser {
                 objType = "Long"
             }
             if (it.'@maxOccurs' == 'unbounded') {
+                // Array detected we need to switch back to native types
+                if (objType == "Long") {
+                    objType = "long"
+                }
+                else if (objType == "Integer") {
+                    objType = "int"
+                }
                 objType = objType + "[]"
             }
             if (it.'@minOccurs' == 'unbounded') {

--- a/src/test/groovy/com/toastcoders/vmware/yavijava/parsers/DataObjectWSDLParserImplTest.groovy
+++ b/src/test/groovy/com/toastcoders/vmware/yavijava/parsers/DataObjectWSDLParserImplTest.groovy
@@ -27,6 +27,7 @@ import org.junit.Test
 public class DataObjectWSDLParserImplTest {
 
     WSDLParser parser
+    List props
 
     @Before
     public void setUp() throws Exception {
@@ -34,6 +35,7 @@ public class DataObjectWSDLParserImplTest {
         File html = new File('src/test/resources/YavijavaClientTest.html')
         String wsdl = new YavijavaDataObjectHTMLClient(html).WSDLDefXML
         parser.parse(wsdl)
+        props = this.parser.dataObject.objProperties
     }
 
     @Test
@@ -43,8 +45,25 @@ public class DataObjectWSDLParserImplTest {
 
     @Test
     public void testParserCatchesLongObjectWhenNeeded() throws Exception {
-        List props = this.parser.dataObject.objProperties
         Property myLongProp = props.find {it.name == "checkLong"} as Property
         assert myLongProp.propType == "Long"
+    }
+
+    @Test
+    public void testParserMakesLongArrayCorrectly() throws Exception {
+        Property myLongArray = props.find {it.name == "longArray"} as Property
+        assert myLongArray.propType == "long[]"
+    }
+
+    @Test
+    public void testParserMakesIntegerWhenIntIsOptional() throws Exception {
+        Property myInt = props.find {it.name == "optionalInt"} as Property
+        assert myInt.propType == "Integer"
+    }
+
+    @Test
+    public void testParserMakesIntArrayWhenIntIsOptional() throws Exception {
+        Property myOptionalIntArray = props.find {it.name == "optionalIntArray"} as Property
+        assert myOptionalIntArray.propType == "int[]"
     }
 }

--- a/src/test/resources/YavijavaClientTest.html
+++ b/src/test/resources/YavijavaClientTest.html
@@ -16,6 +16,9 @@ Your Mom.
                     <element name="ds" type="vim25:ManagedObjectReference" minOccurs="0"/>
                     <element name="fault" type="vim25:LocalizedMethodFault" minOccurs="0"/>
                     <element name="checkLong" type="xsd:long" minOccurs="0"/>
+                    <element name="longArray" type="xsd:long" minOccurs="0" maxOccurs="unbounded"/>
+                    <element name="optionalIntArray" type="xsd:int" minOccurs="0" maxOccurs="unbounded"/>
+                    <element name="optionalInt" type="xsd:int" minOccurs="0"/>
                 </sequence>
             </extension>
         </complexContent>


### PR DESCRIPTION
When a Long or Integer should be an array switch back
to long or int for that property

Fixes #19
