### PR TITLE
When a Calendar type is found be sure to include the import

### DIFF
--- a/src/main/groovy/com/toastcoders/vmware/yavijava/generator/DataObjectGeneratorAbs.groovy
+++ b/src/main/groovy/com/toastcoders/vmware/yavijava/generator/DataObjectGeneratorAbs.groovy
@@ -57,6 +57,10 @@ class DataObjectGeneratorAbs implements Generator {
             String javaClass
             javaClass = DynamicDataTemplate.getPackageName(packageName)
             javaClass += DynamicDataTemplate.getImports()
+            // look for calendar usage to include java.util.Calendar in imports
+            if (dataObject.objProperties.find {it.propType == "Calendar"}) {
+                javaClass += "import java.util.Calendar;\n"
+            }
             javaClass += DynamicDataTemplate.getLicense()
             javaClass += DynamicDataTemplate.getClassDef(dataObject.name, dataObject.extendsBase)
             dataObject.objProperties.each {


### PR DESCRIPTION
When a java.util.Calendar was included as a property type
no import was being added for it.

Fixes #13
