### PR TITLE
feat(template): emit Serializable on generated ArrayOf* classes

### DIFF
--- a/src/main/groovy/com/toastcoders/vmware/yavijava/data/ArrayOfTemplate.groovy
+++ b/src/main/groovy/com/toastcoders/vmware/yavijava/data/ArrayOfTemplate.groovy
@@ -3,7 +3,8 @@ package com.toastcoders.vmware.yavijava.data
 class ArrayOfTemplate extends BaseTemplate {
 
     static String getClassDef(String name) {
-        "public class ${name} {\n"
+        "public class ${name} implements java.io.Serializable {\n" +
+        "    private static final long serialVersionUID = 1L;\n"
     }
 
     static String getField(String type, String name) {

--- a/src/test/groovy/com/toastcoders/vmware/yavijava/generator/WSDLDataObjectGeneratorTest.groovy
+++ b/src/test/groovy/com/toastcoders/vmware/yavijava/generator/WSDLDataObjectGeneratorTest.groovy
@@ -66,7 +66,8 @@ public class WSDLDataObjectGeneratorTest {
     void testArrayOfFileContainsExpectedShape() {
         String content = new File(tempDir, "ArrayOfBatchResult.java").text
         assert content.contains("package com.vmware.vim25")
-        assert content.contains("public class ArrayOfBatchResult {")
+        assert content.contains("public class ArrayOfBatchResult implements java.io.Serializable {")
+        assert content.contains("private static final long serialVersionUID = 1L;")
         assert content.contains("public BatchResult[] BatchResult;")
         assert content.contains("public BatchResult[] getBatchResult()")
         assert content.contains("public BatchResult getBatchResult(int i)")


### PR DESCRIPTION
## Summary

`ArrayOfTemplate.getClassDef()` now emits `implements java.io.Serializable` and `private static final long serialVersionUID = 1L;` on every generated `ArrayOf*` class.

**Why only `ArrayOf*` and not the data objects?**

Generated data objects (e.g. `BatchResult`, `VirtualMachineConfigInfo`) all extend `DynamicData`, which is hand-written and already implements `Serializable` (added in yavijava#328). They inherit it — no template change needed.

`ArrayOf*` classes have no base class. They need `Serializable` declared explicitly, or they won't be serializable at all.

**Why this matters:**

Without this fix, a WSDL regen would silently undo the `Serializable` changes made directly to the 614 `ArrayOf*` files in yavijava#328.

## Test plan

- [x] `./gradlew test` — BUILD SUCCESSFUL
- Updated `WSDLDataObjectGeneratorTest` to assert the new class shape

🤖 Generated with [Claude Code](https://claude.com/claude-code)